### PR TITLE
fix(claude): register skill-telemetry hook via hooks.json

### DIFF
--- a/src/writers/claude.ts
+++ b/src/writers/claude.ts
@@ -35,6 +35,7 @@ export async function installClaudePlugin(options: ClaudePluginOptions): Promise
         author: { name: 'aictrl.dev' },
         homepage: 'https://aictrl.dev',
         mcpServers: './.mcp.json',
+        hooks: './hooks/hooks.json',
       },
       null,
       2,
@@ -73,6 +74,29 @@ export async function installClaudePlugin(options: ClaudePluginOptions): Promise
   await writeFile(join(hooksDir, 'skill-telemetry.sh'), generateClaudeHook(baseUrl), {
     mode: 0o755,
   });
+  await writeFile(
+    join(hooksDir, 'hooks.json'),
+    JSON.stringify(
+      {
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Read',
+              hooks: [
+                {
+                  type: 'command',
+                  command: '${CLAUDE_PLUGIN_ROOT}/hooks/skill-telemetry.sh',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    ) + '\n',
+    'utf-8',
+  );
 
   // Register plugin in settings.json
   await mergeSettings(settingsFile, pluginDirName);

--- a/test/writers/claude.test.ts
+++ b/test/writers/claude.test.ts
@@ -122,6 +122,35 @@ describe('installClaudePlugin', () => {
     expect(settings.enabledPlugins['aictrl-talentrix@aictrl']).toBe(true);
   });
 
+  it('registers PostToolUse Read hook in hooks.json', async () => {
+    await installClaudePlugin({
+      orgSlug: 'talentrix',
+      skills,
+      apiKey: 'sk_live_xxx',
+      baseUrl: 'https://aictrl.dev',
+      pluginsCache,
+      settingsFile,
+    });
+
+    const pluginDir = join(pluginsCache, 'aictrl-talentrix@aictrl');
+    const pluginJson = JSON.parse(
+      await readFile(join(pluginDir, '.claude-plugin', 'plugin.json'), 'utf-8')
+    );
+    expect(pluginJson.hooks).toBe('./hooks/hooks.json');
+
+    const hooksJson = JSON.parse(
+      await readFile(join(pluginDir, 'hooks', 'hooks.json'), 'utf-8')
+    );
+    const postToolUse = hooksJson.hooks.PostToolUse;
+    expect(postToolUse).toHaveLength(1);
+    expect(postToolUse[0].matcher).toBe('Read');
+    expect(postToolUse[0].hooks[0]).toEqual({
+      type: 'command',
+      command: '${CLAUDE_PLUGIN_ROOT}/hooks/skill-telemetry.sh',
+    });
+    expect(existsSync(join(pluginDir, 'hooks', 'skill-telemetry.sh'))).toBe(true);
+  });
+
   it('clears old skills on re-install', async () => {
     await installClaudePlugin({
       orgSlug: 'talentrix',


### PR DESCRIPTION
## Summary
- The Claude writer wrote `hooks/skill-telemetry.sh` but never declared it to Claude Code, so the `PostToolUse → Read` telemetry hook never fired.
- Adds `hooks/hooks.json` registering the script and references it from `plugin.json` via `"hooks": "./hooks/hooks.json"`.
- New test asserts both the `plugin.json` field and the `hooks.json` mapping.

## Test plan
- [x] `npx vitest run` — 50/50 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual: re-run installer against a real org, confirm Claude Code fires the hook on a Read of a SKILL.md file

🤖 Generated with [Claude Code](https://claude.com/claude-code)