### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aictrl/setup",
-  "version": "0.1.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aictrl/setup",
-      "version": "0.1.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aictrl/plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Set up aictrl skills, telemetry, and MCP for Claude Code, OpenCode, and Cursor",
   "type": "module",
   "bin": {
@@ -16,7 +16,15 @@
     "dist",
     "bin"
   ],
-  "keywords": ["aictrl", "claude-code", "opencode", "cursor", "skills", "mcp", "setup"],
+  "keywords": [
+    "aictrl",
+    "claude-code",
+    "opencode",
+    "cursor",
+    "skills",
+    "mcp",
+    "setup"
+  ],
   "author": "aictrl.dev",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Releases the skill-telemetry hook registration fix from #4.

Once merged, tag \`v2.0.1\` and create a GitHub Release to trigger the npm publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)