### PR TITLE
fix(ci): set environment: release on publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- npm trusted publisher for \`@aictrl/plugin\` is configured with environment \`release\`; the workflow was missing it, so OIDC publish failed with 404 (run #24916991499).

## Test plan
- [ ] After merging and re-tagging (or re-running the v2.0.1 release workflow), Publish to npm job succeeds and \`npm view @aictrl/plugin versions\` shows 2.0.1.