### PR TITLE
fix(ci): upgrade npm before publish for OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
           cache: npm
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
## Summary
- Upgrade npm to latest before \`npm publish\` so trusted-publisher OIDC actually works (needs npm >= 11.5.1; Node 22 ships with npm 10.x).
- Without this, the publish step gets a misleading 404 even when the trusted publisher and \`environment: release\` are configured (see run #24917222362).

## Test plan
- [ ] After merging, re-tag/re-release v2.0.1 — Publish to npm succeeds and \`npm view @aictrl/plugin versions\` includes 2.0.1.