### PR TITLE
fix(ci): use Node 24 in publish workflow for npm 11 / OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
           cache: npm
-      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
## Summary
- Node 22 ships with npm 10 (no OIDC trusted publishing). The previous attempt to upgrade npm in-place hit a known dependency bug. Node 24 ships with npm 11 and works.

## Test plan
- [ ] After merging and re-tagging v2.0.1, Publish to npm succeeds.