### PR TITLE
fix(pkg): declare repository for npm provenance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "@aictrl/setup",
+  "name": "@aictrl/plugin",
   "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@aictrl/setup",
+      "name": "@aictrl/plugin",
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0"
       },
       "bin": {
-        "aictrl-setup": "bin/setup.js"
+        "aictrl-plugin": "bin/setup.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,14 @@
   ],
   "author": "aictrl.dev",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aictrl-dev/aictrl-plugin.git"
+  },
+  "homepage": "https://github.com/aictrl-dev/aictrl-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/aictrl-dev/aictrl-plugin/issues"
+  },
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Summary
- Add \`repository\`, \`homepage\`, \`bugs\` to package.json so npm provenance verification accepts the publish (run #24917339054 failed with 422 because repository.url was empty).

## Test plan
- [ ] After merging, re-tag/re-release v2.0.1 — Publish to npm succeeds and \`npm view @aictrl/plugin@2.0.1\` returns metadata.