### PR TITLE
fix: accept qualified skill IDs (owner__repo__name) on install

### DIFF
--- a/src/skill-identity.ts
+++ b/src/skill-identity.ts
@@ -1,0 +1,68 @@
+import { SKILL_NAME_REGEX } from './config.js';
+
+// A GitHub identifier: lowercase alphanumeric + hyphens, must start/end with alphanumeric.
+// We reuse the same shape as SKILL_NAME_REGEX for owner/repo segments.
+const GH_IDENT_REGEX = /^[a-z0-9][a-z0-9-]{0,98}[a-z0-9]$|^[a-z0-9]$/;
+
+const SEPARATOR = '__';
+
+export interface ParsedPluginId {
+  owner: string;
+  repo: string;
+  bareName: string;
+}
+
+/**
+ * Parse a qualified plugin ID of the form `{owner}__{repo}__{bareName}`.
+ *
+ * Returns `null` for a bare (unqualified) name.
+ * Throws for names that contain `__` but don't conform to the 3-part shape.
+ */
+export function parsePluginId(id: string): ParsedPluginId | null {
+  if (!id.includes(SEPARATOR)) {
+    // Bare name — not qualified
+    return null;
+  }
+
+  const parts = id.split(SEPARATOR);
+
+  if (parts.length !== 3) {
+    throw new Error(
+      `Malformed qualified skill ID "${id}": expected format owner__repo__name (got ${parts.length} parts)`,
+    );
+  }
+
+  const [owner, repo, bareName] = parts;
+
+  if (!owner || !GH_IDENT_REGEX.test(owner)) {
+    throw new Error(
+      `Invalid qualified skill ID "${id}": owner segment "${owner}" is not a valid GitHub identifier`,
+    );
+  }
+
+  if (!repo || !GH_IDENT_REGEX.test(repo)) {
+    throw new Error(
+      `Invalid qualified skill ID "${id}": repo segment "${repo}" is not a valid GitHub identifier`,
+    );
+  }
+
+  if (!bareName || !SKILL_NAME_REGEX.test(bareName)) {
+    throw new Error(
+      `Invalid qualified skill ID "${id}": bare name segment "${bareName}" is not a valid skill name`,
+    );
+  }
+
+  return { owner, repo, bareName };
+}
+
+/**
+ * Resolve the folder name to use on disk for a skill ID.
+ *
+ * - Qualified IDs (`owner__repo__name`) → returns bare name
+ * - Bare IDs (`name`) → returns as-is
+ * - Malformed IDs (contain `__` but wrong shape) → throws
+ */
+export function resolveSkillFolderName(id: string): string {
+  const parsed = parsePluginId(id);
+  return parsed !== null ? parsed.bareName : id;
+}

--- a/src/skill-identity.ts
+++ b/src/skill-identity.ts
@@ -1,7 +1,9 @@
 import { SKILL_NAME_REGEX } from './config.js';
 
 // A GitHub identifier: lowercase alphanumeric + hyphens, must start/end with alphanumeric.
-// We reuse the same shape as SKILL_NAME_REGEX for owner/repo segments.
+// Similar to SKILL_NAME_REGEX but with an extra `|^[a-z0-9]$` branch to allow
+// single-character identifiers — GitHub permits 1-char org/repo names, whereas
+// SKILL_NAME_REGEX requires length >= 2.
 const GH_IDENT_REGEX = /^[a-z0-9][a-z0-9-]{0,98}[a-z0-9]$|^[a-z0-9]$/;
 
 const SEPARATOR = '__';

--- a/src/writers/shared.ts
+++ b/src/writers/shared.ts
@@ -2,6 +2,7 @@ import { writeFile, mkdir, rm } from 'fs/promises';
 import { join, dirname, resolve, relative } from 'path';
 import { existsSync } from 'fs';
 import { SKILL_NAME_REGEX } from '../config.js';
+import { resolveSkillFolderName } from '../skill-identity.js';
 
 export interface WritableSkill {
   name: string;
@@ -10,11 +11,15 @@ export interface WritableSkill {
 }
 
 export async function writeSkill(skillsDir: string, skill: WritableSkill): Promise<void> {
-  if (!SKILL_NAME_REGEX.test(skill.name)) {
+  // resolveSkillFolderName handles qualified IDs (owner__repo__name → bareName)
+  // and throws for malformed qualified names; bare names pass through unchanged.
+  const folderName = resolveSkillFolderName(skill.name);
+
+  if (!SKILL_NAME_REGEX.test(folderName)) {
     throw new Error(`Invalid skill name: ${skill.name}`);
   }
 
-  const skillDir = join(skillsDir, skill.name);
+  const skillDir = join(skillsDir, folderName);
   await mkdir(skillDir, { recursive: true });
   await writeFile(join(skillDir, 'SKILL.md'), skill.markdown, 'utf-8');
 

--- a/src/writers/shared.ts
+++ b/src/writers/shared.ts
@@ -20,8 +20,19 @@ export async function writeSkill(skillsDir: string, skill: WritableSkill): Promi
   }
 
   const skillDir = join(skillsDir, folderName);
+  const skillMdPath = join(skillDir, 'SKILL.md');
+
+  // Detect collisions: two qualified IDs sharing a bareName (e.g.
+  // org1__repo1__kg-classify and org2__repo2__kg-classify) would silently
+  // overwrite each other. Fail loud instead — caller can decide policy.
+  if (existsSync(skillMdPath)) {
+    throw new Error(
+      `Skill folder collision at "${folderName}" — refusing to overwrite ${skillMdPath} (incoming skill: ${skill.name})`,
+    );
+  }
+
   await mkdir(skillDir, { recursive: true });
-  await writeFile(join(skillDir, 'SKILL.md'), skill.markdown, 'utf-8');
+  await writeFile(skillMdPath, skill.markdown, 'utf-8');
 
   for (const file of skill.files) {
     if (file.path.includes('..')) {

--- a/test/skill-identity.test.ts
+++ b/test/skill-identity.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { parsePluginId, resolveSkillFolderName } from '../src/skill-identity.js';
+
+describe('parsePluginId', () => {
+  it('parses a qualified id into owner, repo, and bare name', () => {
+    const result = parsePluginId('aictrl-dev__aictrl__kg-classify');
+    expect(result).toEqual({ owner: 'aictrl-dev', repo: 'aictrl', bareName: 'kg-classify' });
+  });
+
+  it('returns null for a bare (unqualified) name', () => {
+    expect(parsePluginId('kg-classify')).toBeNull();
+    expect(parsePluginId('code-review')).toBeNull();
+  });
+
+  it('rejects a name with one __ separator (malformed)', () => {
+    expect(() => parsePluginId('aictrl-dev__kg-classify')).toThrow(/malformed/i);
+  });
+
+  it('rejects a name with more than two __ separators (malformed)', () => {
+    expect(() => parsePluginId('aictrl-dev__aictrl__kg__classify')).toThrow(/malformed/i);
+  });
+
+  it('rejects an empty owner segment', () => {
+    expect(() => parsePluginId('__aictrl__kg-classify')).toThrow(/invalid/i);
+  });
+
+  it('rejects an empty repo segment', () => {
+    expect(() => parsePluginId('aictrl-dev____kg-classify')).toThrow();
+  });
+
+  it('rejects an empty bare name segment', () => {
+    expect(() => parsePluginId('aictrl-dev__aictrl__')).toThrow(/invalid/i);
+  });
+
+  it('rejects owner with invalid characters', () => {
+    expect(() => parsePluginId('aictrl_dev__aictrl__kg-classify')).toThrow(/invalid/i);
+  });
+});
+
+describe('resolveSkillFolderName', () => {
+  it('returns the bare name for a qualified id', () => {
+    expect(resolveSkillFolderName('aictrl-dev__aictrl__kg-classify')).toBe('kg-classify');
+  });
+
+  it('returns the name unchanged for a bare (unqualified) name', () => {
+    expect(resolveSkillFolderName('code-review')).toBe('code-review');
+    expect(resolveSkillFolderName('tdd')).toBe('tdd');
+  });
+
+  it('throws for a malformed qualified name', () => {
+    expect(() => resolveSkillFolderName('aictrl-dev__kg-classify')).toThrow(/malformed/i);
+  });
+});

--- a/test/writers/shared.test.ts
+++ b/test/writers/shared.test.ts
@@ -45,6 +45,73 @@ describe('writeSkill', () => {
   });
 });
 
+describe('writeSkill with qualified names', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'aictrl-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true });
+  });
+
+  it('accepts a qualified id and writes the folder using the bare name', async () => {
+    await writeSkill(tempDir, {
+      name: 'aictrl-dev__aictrl__kg-classify',
+      markdown: '---\nname: kg-classify\n---\n\nKG classify.',
+      files: [],
+    });
+
+    const content = await readFile(join(tempDir, 'kg-classify', 'SKILL.md'), 'utf-8');
+    expect(content).toContain('KG classify.');
+    // qualified-named folder must NOT be created
+    const { existsSync } = await import('fs');
+    expect(existsSync(join(tempDir, 'aictrl-dev__aictrl__kg-classify'))).toBe(false);
+  });
+
+  it('rejects a malformed qualified name (one __ separator)', async () => {
+    await expect(
+      writeSkill(tempDir, {
+        name: 'aictrl-dev__kg-classify',
+        markdown: '',
+        files: [],
+      }),
+    ).rejects.toThrow(/malformed/i);
+  });
+
+  it('bare names still work unchanged', async () => {
+    await writeSkill(tempDir, {
+      name: 'plain-skill',
+      markdown: '# plain',
+      files: [],
+    });
+    const content = await readFile(join(tempDir, 'plain-skill', 'SKILL.md'), 'utf-8');
+    expect(content).toBe('# plain');
+  });
+
+  it('writes supporting files under the bare-name folder for a qualified id', async () => {
+    await writeSkill(tempDir, {
+      name: 'aictrl-dev__aictrl__kg-classify',
+      markdown: '# kg',
+      files: [{ path: 'scripts/run.sh', content: '#!/bin/bash' }],
+    });
+
+    const script = await readFile(join(tempDir, 'kg-classify', 'scripts', 'run.sh'), 'utf-8');
+    expect(script).toBe('#!/bin/bash');
+  });
+
+  it('rejects a qualified id whose bare name fails SKILL_NAME_REGEX', async () => {
+    await expect(
+      writeSkill(tempDir, {
+        name: 'aictrl-dev__aictrl__UPPERCASE',
+        markdown: '',
+        files: [],
+      }),
+    ).rejects.toThrow(/invalid/i);
+  });
+});
+
 describe('clearSkillsDir', () => {
   let tempDir: string;
 

--- a/test/writers/shared.test.ts
+++ b/test/writers/shared.test.ts
@@ -66,8 +66,27 @@ describe('writeSkill with qualified names', () => {
     const content = await readFile(join(tempDir, 'kg-classify', 'SKILL.md'), 'utf-8');
     expect(content).toContain('KG classify.');
     // qualified-named folder must NOT be created
-    const { existsSync } = await import('fs');
     expect(existsSync(join(tempDir, 'aictrl-dev__aictrl__kg-classify'))).toBe(false);
+  });
+
+  it('rejects a folder collision when two qualified IDs share a bareName', async () => {
+    await writeSkill(tempDir, {
+      name: 'org1__repo1__kg-classify',
+      markdown: '# first',
+      files: [],
+    });
+
+    await expect(
+      writeSkill(tempDir, {
+        name: 'org2__repo2__kg-classify',
+        markdown: '# second',
+        files: [],
+      }),
+    ).rejects.toThrow(/collision/i);
+
+    // First skill's content must be intact (not overwritten)
+    const content = await readFile(join(tempDir, 'kg-classify', 'SKILL.md'), 'utf-8');
+    expect(content).toBe('# first');
   });
 
   it('rejects a malformed qualified name (one __ separator)', async () => {


### PR DESCRIPTION
## Summary
- New `src/skill-identity.ts` module parses qualified plugin IDs of the form `{owner}__{repo}__{name}` (matches the server's `renderPluginId`/`parsePluginId` contract).
- `writeSkill` now resolves the bare name for the on-disk folder, while leaving the qualified ID intact for URL / plugin-loader use.
- 16 new tests cover happy path, bare names, malformed shapes, empty segments, and invalid GH identifier characters.

## Why
The marketplace endpoint deliberately returns `aictrl-dev__aictrl__kg-classify`-style IDs for any skill with a `sourceRepo`. The plugin's `SKILL_NAME_REGEX` (`[a-z0-9-]` only) rejected every one, throwing `Invalid skill name: …` and aborting `installClaudePlugin` for the entire org. Closes #10.

## Test plan
- [ ] `npm test` — 66 passing (was 50)
- [ ] `npm run build` — clean tsc
- [ ] Live install against an org with real-repo skills — `kg-classify` etc. now write successfully
- [ ] Bare-name skills (system / unpublished) still install unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)