### PR TITLE
fix: retry skill fetches on 429/5xx and lower batch size

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,4 +19,6 @@ export const CURSOR_MCP_FILE = '.cursor/mcp.json';
 
 export const SKILL_NAME_REGEX = /^[a-z0-9][a-z0-9-]{0,98}[a-z0-9]$/;
 
-export const FETCH_BATCH_SIZE = 10;
+// 4 concurrent skill fetches: conservative enough to avoid 429s on the marketplace endpoint
+// (each skill needs 2–N requests; 4 parallel × ~3 requests = ~12 in-flight max)
+export const FETCH_BATCH_SIZE = 4;

--- a/src/fetch-skills.ts
+++ b/src/fetch-skills.ts
@@ -3,49 +3,88 @@ export interface FetchWithRetryOptions {
   delayMs?: number;
   /** Maximum number of retry attempts. Default 3. */
   maxRetries?: number;
+  /** Human-readable label for error messages (e.g. "SKILL.md for kg-classify"). Avoids leaking the URL, which contains the API key. */
+  label?: string;
+}
+
+// Cap Retry-After to keep retry latency sane even if a misconfigured or
+// adversarial server returns a huge value (e.g. 3600s).
+const MAX_RETRY_AFTER_MS = 30_000;
+
+// Jitter spreads synchronized retries from concurrent requests in the same
+// batch (which would otherwise re-hit the rate limiter in lock-step).
+function withJitter(ms: number): number {
+  return ms * (0.8 + Math.random() * 0.4);
 }
 
 /**
- * Wraps `fetch` with exponential-backoff retry on 429 and 5xx responses.
- * Honors the `Retry-After` response header when present (interpreted as seconds).
- * Non-retryable errors (e.g. 404) are thrown immediately after the first attempt.
+ * Wraps `fetch` with exponential-backoff retry on 429 and 5xx responses, and
+ * on network-level errors (DNS resolution, connection reset, socket timeout —
+ * `fetch` throws a `TypeError` in these cases). Honors the `Retry-After`
+ * response header when present (numeric seconds; HTTP-date format is not
+ * parsed and falls back to the default backoff). Retry-After is capped at
+ * MAX_RETRY_AFTER_MS to keep latency bounded.
+ *
+ * Non-retryable errors (e.g. 404) are thrown immediately after the first
+ * attempt. Error messages use `label` (or fall back to the request method)
+ * rather than the raw URL — the URL contains the caller's API key.
  */
 export async function fetchWithRetry(
   url: string,
   options: FetchWithRetryOptions & RequestInit = {},
 ): Promise<Response> {
-  const { delayMs = 250, maxRetries = 3, ...fetchInit } = options;
+  const { delayMs = 250, maxRetries = 3, label, ...fetchInit } = options;
+  const what = label ?? 'request';
 
   let attempt = 0;
 
   while (true) {
-    const response = await fetch(url, fetchInit);
+    let response: Response;
+    let networkError: unknown = null;
+    try {
+      response = await fetch(url, fetchInit);
+    } catch (err) {
+      networkError = err;
+      response = undefined as unknown as Response;
+    }
+
+    if (networkError !== null) {
+      // Network-level error (TypeError from fetch) — retry with backoff
+      if (attempt >= maxRetries) {
+        throw new Error(`Network error fetching ${what} (after ${attempt} retries): ${(networkError as Error).message}`);
+      }
+      await new Promise<void>(resolve => setTimeout(resolve, withJitter(delayMs * Math.pow(4, attempt))));
+      attempt++;
+      continue;
+    }
 
     const shouldRetry = !response.ok && (response.status === 429 || response.status >= 500);
 
     if (response.ok || !shouldRetry) {
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status} fetching ${url}`);
+        throw new Error(`HTTP ${response.status} fetching ${what}`);
       }
       return response;
     }
 
     if (attempt >= maxRetries) {
-      throw new Error(`HTTP ${response.status} fetching ${url} (after ${attempt} retries)`);
+      throw new Error(`HTTP ${response.status} fetching ${what} (after ${attempt} retries)`);
     }
 
-    // Determine delay: honour Retry-After header if present
+    // Determine delay: honour Retry-After header if present (numeric seconds only)
     const retryAfter = response.headers.get('Retry-After');
     let waitMs: number;
     if (retryAfter !== null) {
       const parsed = parseFloat(retryAfter);
-      waitMs = isNaN(parsed) ? delayMs * Math.pow(4, attempt) : parsed * 1000;
+      waitMs = isNaN(parsed)
+        ? delayMs * Math.pow(4, attempt)
+        : Math.min(parsed * 1000, MAX_RETRY_AFTER_MS);
     } else {
       // Exponential backoff: 250ms, 1000ms, 4000ms
       waitMs = delayMs * Math.pow(4, attempt);
     }
 
-    await new Promise<void>(resolve => setTimeout(resolve, waitMs));
+    await new Promise<void>(resolve => setTimeout(resolve, withJitter(waitMs)));
     attempt++;
   }
 }
@@ -124,13 +163,17 @@ export async function fetchSkillContent(
   const pluginBase = `${baseUrl}/${orgSlug}/${apiKey}/skills.git/plugins/${skill.name}`;
 
   // Fetch SKILL.md
-  const mdResponse = await fetchWithRetry(`${pluginBase}/SKILL.md`);
+  const mdResponse = await fetchWithRetry(`${pluginBase}/SKILL.md`, {
+    label: `SKILL.md for ${skill.name}`,
+  });
   const markdown = await mdResponse.text();
 
   // Fetch plugin.json to check for supporting files
   let pjResponse: Response;
   try {
-    pjResponse = await fetchWithRetry(`${pluginBase}/.claude-plugin/plugin.json`);
+    pjResponse = await fetchWithRetry(`${pluginBase}/.claude-plugin/plugin.json`, {
+      label: `plugin.json for ${skill.name}`,
+    });
   } catch {
     return { markdown, files: [] };
   }
@@ -146,7 +189,9 @@ export async function fetchSkillContent(
 
   for (const file of supportingFiles) {
     try {
-      const fileResponse = await fetchWithRetry(`${pluginBase}/${file.path}`);
+      const fileResponse = await fetchWithRetry(`${pluginBase}/${file.path}`, {
+        label: `${file.path} for ${skill.name}`,
+      });
       files.push({
         path: file.path,
         content: await fileResponse.text(),

--- a/src/fetch-skills.ts
+++ b/src/fetch-skills.ts
@@ -1,3 +1,55 @@
+export interface FetchWithRetryOptions {
+  /** Base delay in ms before first retry (doubles on each attempt). Default 250. */
+  delayMs?: number;
+  /** Maximum number of retry attempts. Default 3. */
+  maxRetries?: number;
+}
+
+/**
+ * Wraps `fetch` with exponential-backoff retry on 429 and 5xx responses.
+ * Honors the `Retry-After` response header when present (interpreted as seconds).
+ * Non-retryable errors (e.g. 404) are thrown immediately after the first attempt.
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: FetchWithRetryOptions & RequestInit = {},
+): Promise<Response> {
+  const { delayMs = 250, maxRetries = 3, ...fetchInit } = options;
+
+  let attempt = 0;
+
+  while (true) {
+    const response = await fetch(url, fetchInit);
+
+    const shouldRetry = !response.ok && (response.status === 429 || response.status >= 500);
+
+    if (response.ok || !shouldRetry) {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} fetching ${url}`);
+      }
+      return response;
+    }
+
+    if (attempt >= maxRetries) {
+      throw new Error(`HTTP ${response.status} fetching ${url} (after ${attempt} retries)`);
+    }
+
+    // Determine delay: honour Retry-After header if present
+    const retryAfter = response.headers.get('Retry-After');
+    let waitMs: number;
+    if (retryAfter !== null) {
+      const parsed = parseFloat(retryAfter);
+      waitMs = isNaN(parsed) ? delayMs * Math.pow(4, attempt) : parsed * 1000;
+    } else {
+      // Exponential backoff: 250ms, 1000ms, 4000ms
+      waitMs = delayMs * Math.pow(4, attempt);
+    }
+
+    await new Promise<void>(resolve => setTimeout(resolve, waitMs));
+    attempt++;
+  }
+}
+
 export interface MarketplaceSkill {
   name: string;
   description: string;
@@ -72,15 +124,14 @@ export async function fetchSkillContent(
   const pluginBase = `${baseUrl}/${orgSlug}/${apiKey}/skills.git/plugins/${skill.name}`;
 
   // Fetch SKILL.md
-  const mdResponse = await fetch(`${pluginBase}/SKILL.md`);
-  if (!mdResponse.ok) {
-    throw new Error(`Failed to fetch SKILL.md for ${skill.name} (status ${mdResponse.status})`);
-  }
+  const mdResponse = await fetchWithRetry(`${pluginBase}/SKILL.md`);
   const markdown = await mdResponse.text();
 
   // Fetch plugin.json to check for supporting files
-  const pjResponse = await fetch(`${pluginBase}/.claude-plugin/plugin.json`);
-  if (!pjResponse.ok) {
+  let pjResponse: Response;
+  try {
+    pjResponse = await fetchWithRetry(`${pluginBase}/.claude-plugin/plugin.json`);
+  } catch {
     return { markdown, files: [] };
   }
 
@@ -94,12 +145,14 @@ export async function fetchSkillContent(
   const files: SkillFile[] = [];
 
   for (const file of supportingFiles) {
-    const fileResponse = await fetch(`${pluginBase}/${file.path}`);
-    if (fileResponse.ok) {
+    try {
+      const fileResponse = await fetchWithRetry(`${pluginBase}/${file.path}`);
       files.push({
         path: file.path,
         content: await fileResponse.text(),
       });
+    } catch {
+      // Skip files that fail even after retries
     }
   }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -19,7 +19,9 @@ describe('config', () => {
     expect(SKILL_NAME_REGEX.test('HAS-CAPS')).toBe(false);
   });
 
-  it('fetch batch size is reasonable', () => {
-    expect(FETCH_BATCH_SIZE).toBe(10);
+  it('fetch batch size is conservative to avoid 429s', () => {
+    expect(FETCH_BATCH_SIZE).toBe(4);
+    expect(FETCH_BATCH_SIZE).toBeGreaterThan(0);
+    expect(FETCH_BATCH_SIZE).toBeLessThanOrEqual(5);
   });
 });

--- a/test/fetch-skills.test.ts
+++ b/test/fetch-skills.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { fetchMarketplace, fetchSkillContent, type MarketplaceSkill } from '../src/fetch-skills.js';
+import { fetchMarketplace, fetchSkillContent, fetchWithRetry, type MarketplaceSkill } from '../src/fetch-skills.js';
 
 const fixturesDir = join(import.meta.dirname, 'fixtures');
 const marketplaceFixture = JSON.parse(readFileSync(join(fixturesDir, 'marketplace.json'), 'utf-8'));
@@ -114,5 +114,83 @@ describe('fetchSkillContent', () => {
     expect(content.files).toHaveLength(1);
     expect(content.files[0].path).toBe('references/checklist.md');
     expect(content.files[0].content).toContain('Checklist');
+  });
+});
+
+describe('fetchWithRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('retries on 429 and eventually returns successful response', async () => {
+    const mockFetch = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({ ok: false, status: 429, headers: new Headers() } as Response)
+      .mockResolvedValueOnce({ ok: false, status: 429, headers: new Headers() } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, headers: new Headers(), text: () => Promise.resolve('body') } as unknown as Response);
+
+    const promise = fetchWithRetry('https://example.com/file', { delayMs: 10 });
+    // Advance through the two back-off delays
+    await vi.runAllTimersAsync();
+    const response = await promise;
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(response.ok).toBe(true);
+  });
+
+  it('honors Retry-After header (seconds)', async () => {
+    const retryAfterHeaders = new Headers({ 'Retry-After': '0.05' });
+    const mockFetch = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({ ok: false, status: 429, headers: retryAfterHeaders } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, headers: new Headers() } as unknown as Response);
+
+    const promise = fetchWithRetry('https://example.com/file', { delayMs: 10 });
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // With Retry-After: 0.05 the delay should have been ~50ms, not the default 10ms
+    // We only assert it didn't throw and returned on 2nd attempt
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after all retries are exhausted on persistent 429', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: false, status: 429, headers: new Headers() } as Response);
+
+    const promise = fetchWithRetry('https://example.com/file', { delayMs: 10, maxRetries: 3 });
+    // Attach rejection handler before advancing timers to prevent unhandled rejection
+    const caught = promise.catch(e => e);
+    await vi.runAllTimersAsync();
+    const err = await caught;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain('429');
+  });
+
+  it('does NOT retry on 404 — throws immediately', async () => {
+    const mockFetch = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: false, status: 404, headers: new Headers() } as Response);
+
+    await expect(fetchWithRetry('https://example.com/missing', { delayMs: 10 }))
+      .rejects.toThrow('404');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 5xx (503) and returns successful response', async () => {
+    const mockFetch = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({ ok: false, status: 503, headers: new Headers() } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, headers: new Headers() } as unknown as Response);
+
+    const promise = fetchWithRetry('https://example.com/file', { delayMs: 10 });
+    await vi.runAllTimersAsync();
+    const response = await promise;
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(response.ok).toBe(true);
   });
 });

--- a/test/fetch-skills.test.ts
+++ b/test/fetch-skills.test.ts
@@ -193,4 +193,59 @@ describe('fetchWithRetry', () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(response.ok).toBe(true);
   });
+
+  it('retries on network-level errors (TypeError thrown by fetch)', async () => {
+    const mockFetch = vi.spyOn(globalThis, 'fetch')
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce({ ok: true, status: 200, headers: new Headers() } as unknown as Response);
+
+    const promise = fetchWithRetry('https://example.com/file', { delayMs: 10 });
+    await vi.runAllTimersAsync();
+    const response = await promise;
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(response.ok).toBe(true);
+  });
+
+  it('throws after exhausting retries on persistent network errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('ECONNRESET'));
+
+    const promise = fetchWithRetry('https://example.com/file', { delayMs: 10, maxRetries: 2 });
+    const caught = promise.catch(e => e);
+    await vi.runAllTimersAsync();
+    const err = await caught;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/network error/i);
+    expect((err as Error).message).toContain('ECONNRESET');
+  });
+
+  it('uses label in error messages instead of raw URL (which contains the API key)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 404, headers: new Headers() } as Response);
+
+    const sensitiveUrl = 'https://aictrl.dev/talentrix/sk_live_SECRET/skills.git/plugins/foo/SKILL.md';
+    const promise = fetchWithRetry(sensitiveUrl, { delayMs: 10, label: 'SKILL.md for foo' });
+
+    await expect(promise).rejects.toThrow(/SKILL\.md for foo/);
+    await expect(
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 404, headers: new Headers() } as Response) &&
+      fetchWithRetry(sensitiveUrl, { delayMs: 10, label: 'SKILL.md for foo' })
+    ).rejects.not.toThrow(/sk_live_SECRET/);
+  });
+
+  it('caps Retry-After at 30s to prevent unbounded delay', async () => {
+    // Server returns Retry-After: 3600 (1 hour) — should cap at 30s
+    const retryAfterHeaders = new Headers({ 'Retry-After': '3600' });
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({ ok: false, status: 429, headers: retryAfterHeaders } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, headers: new Headers() } as unknown as Response);
+
+    const promise = fetchWithRetry('https://example.com/file', { delayMs: 10 });
+    // Advance just past the 30s cap (with jitter up to 1.2x = 36s)
+    await vi.advanceTimersByTimeAsync(40_000);
+    const response = await promise;
+
+    expect(response.ok).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- New `fetchWithRetry` helper in `src/fetch-skills.ts` retries 429 and 5xx with exponential backoff (250ms → 1s → 4s, 3 retries). Honors `Retry-After` header. Non-retryable errors (e.g. 404) throw immediately as before.
- All three `fetch` call sites in `fetchSkillContent` (SKILL.md, plugin.json, supporting files) now use the helper.
- `FETCH_BATCH_SIZE` reduced from 10 to 4 in `src/config.ts` with a one-line rationale comment.
- 5 new tests cover: retry-then-succeed on 429, `Retry-After` honored, exhausted retries throws, 404 no-retry, 503-then-200.

## Why
Live install against the `aictrl` org (46 skills) silently dropped 17 of them — every batch of 10 parallel fetches hit the marketplace rate limiter, and the plugin treated 429 as a hard skip. Closes #11.

## Notes / non-goals
- `fetchMarketplace` is intentionally NOT wrapped — a 429 on the very first request should fail loud, not silently degrade the install.
- Tests use Vitest fake timers so the 5s+ backoff schedule doesn't slow the suite.

## Test plan
- [ ] `npm test` — 55 passing (was 50)
- [ ] `npm run build` — clean tsc
- [ ] Live install against `aictrl` org — all 46 skills installed (was 29/46)

🤖 Generated with [Claude Code](https://claude.com/claude-code)