### PR TITLE
chore(deps): bump postcss to 8.5.10 (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1668,9 +1668,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Bumps transitive dev dep `postcss` from 8.5.9 → 8.5.10 via lockfile update.
- Closes Dependabot alert #1.

## Why
GHSA-qx2v-qp2m-jg93 (CVE-2026-41305) — XSS via unescaped `</style>` when parsing untrusted CSS and re-stringifying for HTML embedding.

**Impact on this plugin: effectively zero.** postcss enters via `vitest 3.2.4 → vite 7.3.2 → postcss`, scope `development`. Not in `dist/` or `bin/` (the only published paths), so no runtime exposure. Bumping anyway to keep the alert list clean.

## Test plan
- [x] `npm test` — 50 passing, unchanged
- [x] `npm run build` — clean tsc
- [x] `npm ls postcss` shows 8.5.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)