### PR TITLE
chore(release): 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aictrl/plugin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aictrl/plugin",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aictrl/plugin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Set up aictrl skills, telemetry, and MCP for Claude Code, OpenCode, and Cursor",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Bumps `package.json` 2.0.1 → 2.0.2.

## Changes since 2.0.1
- **#12** — install no longer aborts on real-repo skills (qualified IDs `owner__repo__name` now resolve to bare-name folders). Was a P1 data-loss bug.
- **#13** — SKILL.md fetches retry on 429/5xx + network errors with jittered exponential backoff; `FETCH_BATCH_SIZE` lowered 10 → 4. Eliminates the ~37% silent-skip rate against moderately-sized orgs.
- **#14** — `postcss` bumped to 8.5.10 (transitive dev dep, GHSA-qx2v-qp2m-jg93). No runtime impact.

All three are bug fixes — no API change, no new feature surface — so this is a patch bump per semver.

## Release plan
After merge: tag `v2.0.2` and create GitHub Release. The publish workflow (`.github/workflows/publish.yml`) is triggered by `release: published` and will run `npm ci → build → test → npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)