### PR TITLE
chore(release): v2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aictrl/plugin",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aictrl/plugin",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aictrl/plugin",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Set up aictrl skills, telemetry, and MCP for Claude Code, OpenCode, and Cursor",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump `@aictrl/plugin` to **2.1.0** (semver minor — additive feature)
- Ships the slash-command telemetry hook from #16: closes the gap where user-typed `/<skill>` invocations were invisible to PostToolUse and never reached `/analytics/skills`

## Release notes

### Added
- Claude Code `UserPromptSubmit` hook (`slash-command-telemetry.sh`) that detects `/<skill-name>` and `/<plugin>:<skill-name>` patterns in the user's prompt, validates them against locally installed skills/commands (including plugin-shipped commands under `~/.claude/plugins/cache`), and posts telemetry with `source: "claude-code-slash"`.
- Built-in Claude commands (`/help`, `/clear`, `/config`, …) are filtered implicitly via filesystem validation.

Refs: aictrl-dev/aictrl#1255

## Test plan

- [x] CI green on the feature PR (#16) — 97 tests including 11 new edge-case + plugin-command tests
- [ ] After merge: tag `v2.1.0` and `gh release create` triggers `publish.yml` → `npm publish --access public`