### PR TITLE
chore(release): v2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aictrl/plugin",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aictrl/plugin",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aictrl/plugin",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Set up aictrl skills, telemetry, and MCP for Claude Code, OpenCode, and Cursor",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Cuts v2.2.0. Bumps `package.json` and `package-lock.json`. No code changes.

## Included since v2.1.0

- **#19 (closes #18) — Register the `aictrl` marketplace so Claude Code can resolve plugin enablement.** Pre-v2.2, `npx @aictrl/plugin` wrote the plugin to `~/.claude/plugins/cache/<plugin>@aictrl/` and flipped `enabledPlugins["<plugin>@aictrl"] = true`, but it never registered the `aictrl` marketplace, never wrote a marketplace manifest, and never recorded the install. Claude Code printed `Plugin "aictrl-<org>" not found in marketplace "aictrl"` on every launch and skills/MCP failed to resolve. v2.2 switches to the canonical Claude Code layout, writes the marketplace manifest, registers in `known_marketplaces.json` and `installed_plugins.json`, and cleans up the orphan pre-v2.2 cache directory on upgrade.
- **#21 (closes #20) — Per-project enablement so multi-org developers get only their current repo's MCP + skills.** Pre-v2.2 enablement landed in user-scope `~/.claude/settings.json`, so a developer with access to two orgs (e.g. `celliq` + `talentrix`) saw both MCPs connect and both skill sets load in every Claude Code session everywhere. v2.2 writes enablement to project-scope `<projectDir>/.claude/settings.local.json`, auto-adds that file to project `.gitignore`, and migrates any pre-v2.2 user-scope entry for the installed org out of `~/.claude/settings.json`. Other orgs' entries are preserved — they migrate when the user re-runs the installer in those repos.
- Hardening from PR review: input validation on `orgSlug` (rejects path-traversal sequences), atomic write (tmp + rename) for user-owned settings files to survive a SIGKILL/power-loss mid-write, POSIX-separator literal for the gitignore entry (Windows correctness), `!Array.isArray` guards in all JSON-merge helpers, scope-preserving re-install in `installed_plugins.json`, and cross-file index-consistency regression test.

## Semver

Minor bump. Backward-compatible at the CLI level — `npx @aictrl/plugin` is invoked the same way, but the on-disk effect (where files land, which Claude Code can now actually load) is different. The internal `ClaudePluginOptions` type changed shape (`settingsFile` → `projectDir` + `userSettingsFile`); there are no external consumers of the type.

## Test plan

- [x] `npm test` — 116/116 pass
- [x] `npm run build` — clean tsc
- [ ] After merge: `gh release create v2.2.0` to trigger `.github/workflows/publish.yml` → npm publish
- [ ] Post-publish: `npx @aictrl/plugin@2.2.0` end-to-end in a real org, confirm no "not found in marketplace" banner and only that org's MCP loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)