### PR TITLE
Add first-class Codex setup support

### DIFF
--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,0 +1,22 @@
+# Codex Support
+
+`@aictrl/plugin --editors codex` installs a local Codex plugin into the personal marketplace and
+adds an aictrl MCP server to Codex config.
+
+The MCP entry is written to `~/.codex/config.toml` as:
+
+```toml
+[mcp_servers.aictrl-<orgSlug>]
+url = "https://aictrl.dev/<orgSlug>/mcp"
+bearer_token_env_var = "AICTRL_API_KEY"
+```
+
+The installer intentionally uses `bearer_token_env_var` instead of writing the API key into Codex
+config. Start Codex with `AICTRL_API_KEY` in the environment so the MCP server can authenticate.
+
+## Telemetry Limitation
+
+Codex does not currently expose a stable skill-invocation hook surface that this package can use to
+emit a reliable `source: "codex"` skill-usage event. The Codex installer therefore does not install
+or claim skill-usage telemetry for Codex. Skills and MCP are installed; telemetry remains disabled
+until Codex exposes a supported invocation hook or plugin telemetry surface.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aictrl/plugin",
   "version": "2.2.0",
-  "description": "Set up aictrl skills, telemetry, and MCP for Claude Code, OpenCode, and Cursor",
+  "description": "Set up aictrl skills, telemetry, and MCP for Claude Code, OpenCode, Cursor, and Codex",
   "type": "module",
   "bin": {
     "aictrl-plugin": "bin/setup.js"
@@ -21,6 +21,7 @@
     "claude-code",
     "opencode",
     "cursor",
+    "codex",
     "skills",
     "mcp",
     "setup"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,8 @@ import {
   PROJECT_CONFIG_FILE,
   CLAUDE_PLUGINS_ROOT,
   CLAUDE_SETTINGS_FILE,
+  CODEX_CONFIG_FILE,
+  CODEX_MARKETPLACE_FILE,
   FETCH_BATCH_SIZE,
 } from './config.js';
 import { readCredentials, writeOrgCredential, readProjectConfig, writeProjectConfig } from './credentials.js';
@@ -15,8 +17,10 @@ import { fetchMarketplace, fetchSkillContent, type MarketplaceSkill } from './fe
 import { installClaudePlugin } from './writers/claude.js';
 import { installOpenCode } from './writers/opencode.js';
 import { installCursor } from './writers/cursor.js';
+import { installCodex } from './writers/codex.js';
 import { ensureGitignore } from './gitignore.js';
-import { printPostInstallMessage, type Editor } from './post-install-message.js';
+import { printPostInstallMessage } from './post-install-message.js';
+import { EDITOR_CHOICES, parseEditors, type Editor } from './editors.js';
 import type { WritableSkill } from './writers/shared.js';
 
 interface CliOptions {
@@ -46,17 +50,6 @@ function parseCliArgs(): CliOptions {
     nonInteractive: (values['non-interactive'] as boolean) ?? false,
     baseUrl: (values['base-url'] as string) ?? DEFAULT_BASE_URL,
   };
-}
-
-const VALID_EDITORS = new Set<string>(['claude', 'opencode', 'cursor']);
-
-function parseEditors(editorsStr: string): Editor[] {
-  const editors = editorsStr.split(',').map(e => e.trim());
-  const invalid = editors.filter(e => !VALID_EDITORS.has(e));
-  if (invalid.length > 0) {
-    throw new Error(`Unknown editor(s): ${invalid.join(', ')}. Valid options: claude, opencode, cursor`);
-  }
-  return editors as Editor[];
 }
 
 async function resolveOrg(options: CliOptions): Promise<string> {
@@ -92,11 +85,7 @@ async function resolveEditors(options: CliOptions): Promise<Editor[]> {
 
   const selected = await checkbox({
     message: 'Select editors to configure:',
-    choices: [
-      { name: 'Claude Code', value: 'claude' as const },
-      { name: 'OpenCode', value: 'opencode' as const },
-      { name: 'Cursor', value: 'cursor' as const },
-    ],
+    choices: EDITOR_CHOICES,
   });
 
   if (selected.length === 0) {
@@ -218,6 +207,21 @@ async function main(): Promise<void> {
     console.log(`    ✓ Configured MCP server in .cursor/mcp.json`);
     console.log('    ✓ Installed telemetry hook\n');
     gitignoreEntries.push('.cursor/mcp.json');
+  }
+
+  if (editors.includes('codex')) {
+    console.log('  Codex:');
+    await installCodex({
+      orgSlug,
+      skills,
+      baseUrl: options.baseUrl,
+      codexConfigFile: CODEX_CONFIG_FILE,
+      codexMarketplaceFile: CODEX_MARKETPLACE_FILE,
+    });
+    console.log(`    ✓ Wrote ${skills.length} skills to Codex plugin aictrl-${orgSlug}`);
+    console.log(`    ✓ Registered Codex personal marketplace entry`);
+    console.log(`    ✓ Configured MCP server in ${CODEX_CONFIG_FILE}`);
+    console.log('    ℹ Codex skill telemetry not installed: no stable skill-invocation hook\n');
   }
 
   // 7. Update .gitignore

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,10 @@ export const PROJECT_CONFIG_FILE = '.aictrl.json';
 export const CLAUDE_PLUGINS_ROOT = join(homedir(), '.claude', 'plugins');
 export const CLAUDE_SETTINGS_FILE = join(homedir(), '.claude', 'settings.json');
 
+export const CODEX_HOME = process.env.CODEX_HOME ?? join(homedir(), '.codex');
+export const CODEX_CONFIG_FILE = join(CODEX_HOME, 'config.toml');
+export const CODEX_MARKETPLACE_FILE = join(homedir(), '.agents', 'plugins', 'marketplace.json');
+
 export const OPENCODE_SKILLS_DIR = '.opencode/skills';
 export const OPENCODE_HOOKS_DIR = '.opencode/hooks';
 

--- a/src/editors.ts
+++ b/src/editors.ts
@@ -1,0 +1,21 @@
+export type Editor = 'claude' | 'opencode' | 'cursor' | 'codex';
+
+export const VALID_EDITORS: readonly Editor[] = ['claude', 'opencode', 'cursor', 'codex'];
+
+export const EDITOR_CHOICES: ReadonlyArray<{ name: string; value: Editor }> = [
+  { name: 'Claude Code', value: 'claude' },
+  { name: 'OpenCode', value: 'opencode' },
+  { name: 'Cursor', value: 'cursor' },
+  { name: 'Codex', value: 'codex' },
+];
+
+export function parseEditors(editorsStr: string): Editor[] {
+  const editors = editorsStr.split(',').map(e => e.trim());
+  const invalid = editors.filter(e => !VALID_EDITORS.includes(e as Editor));
+  if (invalid.length > 0) {
+    throw new Error(
+      `Unknown editor(s): ${invalid.join(', ')}. Valid options: ${VALID_EDITORS.join(', ')}`,
+    );
+  }
+  return editors as Editor[];
+}

--- a/src/post-install-message.ts
+++ b/src/post-install-message.ts
@@ -1,4 +1,6 @@
-export type Editor = 'claude' | 'opencode' | 'cursor';
+import type { Editor } from './editors.js';
+
+export type { Editor };
 
 export function printPostInstallMessage(orgSlug: string, editors: Editor[]): void {
   console.log('  Done! Skills are ready to use.');
@@ -9,6 +11,14 @@ export function printPostInstallMessage(orgSlug: string, editors: Editor[]): voi
     console.log('  run this in Claude Code to clean up the legacy plugin:');
     console.log('');
     console.log(`    /plugin uninstall aictrl-${orgSlug}@aictrl-skills`);
+    console.log('');
+  }
+
+  if (editors.includes('codex')) {
+    console.log('');
+    console.log('  Codex MCP auth uses AICTRL_API_KEY from your environment.');
+    console.log('  Codex skill telemetry is not installed yet because Codex does not');
+    console.log('  expose a stable skill-invocation hook surface.');
     console.log('');
   }
 

--- a/src/writers/codex.ts
+++ b/src/writers/codex.ts
@@ -1,0 +1,217 @@
+import { chmod, mkdir, readFile, rename, rm, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { clearSkillsDir, writeSkill, type WritableSkill } from './shared.js';
+
+export interface CodexOptions {
+  orgSlug: string;
+  skills: WritableSkill[];
+  baseUrl: string;
+  codexConfigFile: string;
+  codexMarketplaceFile: string;
+}
+
+const PLUGIN_VERSION = '1.0.0';
+const MARKETPLACE_NAME = 'personal';
+const MARKETPLACE_DISPLAY_NAME = 'Personal';
+const ORG_SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,62}$/;
+const AICTRL_API_KEY_ENV = 'AICTRL_API_KEY';
+
+interface CodexMarketplace {
+  name: string;
+  interface: {
+    displayName: string;
+    [key: string]: unknown;
+  };
+  plugins: unknown[];
+  [key: string]: unknown;
+}
+
+export async function installCodex(options: CodexOptions): Promise<void> {
+  const { orgSlug, skills, baseUrl, codexConfigFile, codexMarketplaceFile } = options;
+  if (!ORG_SLUG_REGEX.test(orgSlug)) {
+    throw new Error(
+      `Invalid orgSlug "${orgSlug}": must match ${ORG_SLUG_REGEX} (lowercase alphanumeric and hyphens, 1-63 chars).`,
+    );
+  }
+
+  const pluginId = `aictrl-${orgSlug}`;
+  const marketplaceRoot = dirname(codexMarketplaceFile);
+  const pluginDir = join(marketplaceRoot, 'plugins', pluginId);
+  const skillsDir = join(pluginDir, 'skills');
+
+  await clearSkillsDir(skillsDir);
+  for (const skill of skills) {
+    await writeSkill(skillsDir, skill);
+  }
+
+  await writePluginManifest(pluginDir, pluginId, orgSlug);
+  await mergeMarketplace(codexMarketplaceFile, pluginId);
+  await mergeCodexMcpConfig(codexConfigFile, orgSlug, baseUrl);
+}
+
+async function writePluginManifest(
+  pluginDir: string,
+  pluginId: string,
+  orgSlug: string,
+): Promise<void> {
+  const manifestDir = join(pluginDir, '.codex-plugin');
+  await mkdir(manifestDir, { recursive: true });
+  await writeFile(
+    join(manifestDir, 'plugin.json'),
+    JSON.stringify(
+      {
+        name: pluginId,
+        version: PLUGIN_VERSION,
+        description: `aictrl skills for ${orgSlug}`,
+        author: { name: 'aictrl.dev', url: 'https://aictrl.dev' },
+        homepage: 'https://aictrl.dev',
+        license: 'MIT',
+        keywords: ['aictrl', 'skills', 'mcp'],
+        skills: './skills/',
+        interface: {
+          displayName: `aictrl ${orgSlug}`,
+          shortDescription: `aictrl skills and MCP for ${orgSlug}`,
+          longDescription:
+            'Installs aictrl skills for Codex and connects Codex to the aictrl MCP server using environment-backed authentication.',
+          developerName: 'aictrl.dev',
+          category: 'Productivity',
+          capabilities: ['Write', 'MCP'],
+          websiteURL: 'https://aictrl.dev',
+          defaultPrompt: [
+            'Use the aictrl skills for this repository.',
+            'Connect to the aictrl MCP context.',
+          ],
+        },
+      },
+      null,
+      2,
+    ) + '\n',
+    'utf-8',
+  );
+}
+
+async function mergeMarketplace(marketplaceFile: string, pluginId: string): Promise<void> {
+  const marketplaceRoot = dirname(marketplaceFile);
+  let marketplace: CodexMarketplace = {
+    name: MARKETPLACE_NAME,
+    interface: { displayName: MARKETPLACE_DISPLAY_NAME },
+    plugins: [],
+  };
+
+  try {
+    const parsed = JSON.parse(await readFile(marketplaceFile, 'utf-8'));
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      marketplace = {
+        ...marketplace,
+        ...(parsed as Record<string, unknown>),
+        interface: {
+          ...marketplace.interface,
+          ...((parsed as { interface?: unknown }).interface &&
+          typeof (parsed as { interface?: unknown }).interface === 'object' &&
+          !Array.isArray((parsed as { interface?: unknown }).interface)
+            ? ((parsed as { interface: Record<string, unknown> }).interface)
+            : {}),
+        },
+        plugins: Array.isArray((parsed as { plugins?: unknown }).plugins)
+          ? (parsed as { plugins: unknown[] }).plugins
+          : [],
+      };
+    }
+  } catch {
+    // No existing marketplace or malformed JSON: write a valid personal marketplace.
+  }
+
+  marketplace.name = typeof marketplace.name === 'string' ? marketplace.name : MARKETPLACE_NAME;
+  marketplace.interface = marketplace.interface ?? { displayName: MARKETPLACE_DISPLAY_NAME };
+  if (typeof marketplace.interface.displayName !== 'string') {
+    marketplace.interface.displayName = MARKETPLACE_DISPLAY_NAME;
+  }
+
+  const entry = {
+    name: pluginId,
+    source: {
+      source: 'local',
+      path: `./plugins/${pluginId}`,
+    },
+    policy: {
+      installation: 'INSTALLED_BY_DEFAULT',
+      authentication: 'ON_USE',
+    },
+    category: 'Productivity',
+  };
+
+  const others = marketplace.plugins.filter(
+    (plugin): plugin is Record<string, unknown> =>
+      typeof plugin === 'object' &&
+      plugin !== null &&
+      (plugin as { name?: unknown }).name !== pluginId,
+  );
+  marketplace.plugins = [...others, entry];
+
+  await mkdir(marketplaceRoot, { recursive: true });
+  await writeJsonAtomic(marketplaceFile, marketplace);
+}
+
+async function mergeCodexMcpConfig(
+  codexConfigFile: string,
+  orgSlug: string,
+  baseUrl: string,
+): Promise<void> {
+  const serverName = `aictrl-${orgSlug}`;
+  const block = [
+    `[mcp_servers.${serverName}]`,
+    `url = ${tomlString(`${baseUrl}/${orgSlug}/mcp`)}`,
+    `bearer_token_env_var = ${tomlString(AICTRL_API_KEY_ENV)}`,
+  ].join('\n');
+
+  let content = '';
+  try {
+    content = await readFile(codexConfigFile, 'utf-8');
+  } catch {
+    // No existing config: create it below.
+  }
+
+  const next = replaceTomlTable(content, `mcp_servers.${serverName}`, block);
+  await mkdir(dirname(codexConfigFile), { recursive: true });
+  await writeFileAtomic(codexConfigFile, next);
+  await chmod(codexConfigFile, 0o600);
+}
+
+function replaceTomlTable(content: string, tableName: string, replacement: string): string {
+  const lines = content.split(/\r?\n/);
+  const headerPattern = new RegExp(`^\\s*\\[${escapeRegExp(tableName)}\\]\\s*$`);
+  const nextHeaderPattern = /^\s*\[[^\]]+\]\s*$/;
+  const start = lines.findIndex((line) => headerPattern.test(line));
+
+  if (start === -1) {
+    const trimmed = content.trimEnd();
+    return `${trimmed}${trimmed ? '\n\n' : ''}${replacement}\n`;
+  }
+
+  let end = start + 1;
+  while (end < lines.length && !nextHeaderPattern.test(lines[end])) {
+    end += 1;
+  }
+
+  const updated = [...lines.slice(0, start), replacement, ...lines.slice(end)].join('\n');
+  return updated.endsWith('\n') ? updated : `${updated}\n`;
+}
+
+function tomlString(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function writeJsonAtomic(filePath: string, data: unknown): Promise<void> {
+  await writeFileAtomic(filePath, JSON.stringify(data, null, 2) + '\n');
+}
+
+async function writeFileAtomic(filePath: string, content: string): Promise<void> {
+  const tmp = `${filePath}.tmp`;
+  await rm(tmp, { force: true });
+  await writeFile(tmp, content, 'utf-8');
+  await rename(tmp, filePath);
+}

--- a/src/writers/codex.ts
+++ b/src/writers/codex.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, readFile, rename, rm, writeFile } from 'fs/promises';
+import { chmod, cp, mkdir, readFile, rename, rm, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { clearSkillsDir, writeSkill, type WritableSkill } from './shared.js';
 
@@ -36,8 +36,18 @@ export async function installCodex(options: CodexOptions): Promise<void> {
 
   const pluginId = `aictrl-${orgSlug}`;
   const marketplaceRoot = dirname(codexMarketplaceFile);
-  const pluginDir = join(marketplaceRoot, 'plugins', pluginId);
+  const personalMarketplaceRoot = dirname(dirname(marketplaceRoot));
+  const pluginDir = join(personalMarketplaceRoot, 'plugins', pluginId);
+  const legacyPluginDir = join(marketplaceRoot, 'plugins', pluginId);
   const skillsDir = join(pluginDir, 'skills');
+  const pluginCacheDir = join(
+    dirname(codexConfigFile),
+    'plugins',
+    'cache',
+    MARKETPLACE_NAME,
+    pluginId,
+    PLUGIN_VERSION,
+  );
 
   await clearSkillsDir(skillsDir);
   for (const skill of skills) {
@@ -45,8 +55,11 @@ export async function installCodex(options: CodexOptions): Promise<void> {
   }
 
   await writePluginManifest(pluginDir, pluginId, orgSlug);
+  await rm(legacyPluginDir, { recursive: true, force: true });
   await mergeMarketplace(codexMarketplaceFile, pluginId);
+  await installPluginCache(pluginDir, pluginCacheDir);
   await mergeCodexMcpConfig(codexConfigFile, orgSlug, baseUrl);
+  await mergeCodexPluginConfig(codexConfigFile, pluginId);
 }
 
 async function writePluginManifest(
@@ -152,6 +165,12 @@ async function mergeMarketplace(marketplaceFile: string, pluginId: string): Prom
   await writeJsonAtomic(marketplaceFile, marketplace);
 }
 
+async function installPluginCache(pluginDir: string, pluginCacheDir: string): Promise<void> {
+  await rm(pluginCacheDir, { recursive: true, force: true });
+  await mkdir(dirname(pluginCacheDir), { recursive: true });
+  await cp(pluginDir, pluginCacheDir, { recursive: true });
+}
+
 async function mergeCodexMcpConfig(
   codexConfigFile: string,
   orgSlug: string,
@@ -172,6 +191,24 @@ async function mergeCodexMcpConfig(
   }
 
   const next = replaceTomlTable(content, `mcp_servers.${serverName}`, block);
+  await mkdir(dirname(codexConfigFile), { recursive: true });
+  await writeFileAtomic(codexConfigFile, next);
+  await chmod(codexConfigFile, 0o600);
+}
+
+async function mergeCodexPluginConfig(codexConfigFile: string, pluginId: string): Promise<void> {
+  const pluginKey = `${pluginId}@${MARKETPLACE_NAME}`;
+  const tableName = `plugins.${tomlString(pluginKey)}`;
+  const block = [`[${tableName}]`, 'enabled = true'].join('\n');
+
+  let content = '';
+  try {
+    content = await readFile(codexConfigFile, 'utf-8');
+  } catch {
+    // No existing config: create it below.
+  }
+
+  const next = replaceTomlTable(content, tableName, block);
   await mkdir(dirname(codexConfigFile), { recursive: true });
   await writeFileAtomic(codexConfigFile, next);
   await chmod(codexConfigFile, 0o600);

--- a/test/editors.test.ts
+++ b/test/editors.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { EDITOR_CHOICES, parseEditors, VALID_EDITORS } from '../src/editors.js';
+
+describe('editors', () => {
+  it('parses codex in non-interactive editor lists', () => {
+    expect(parseEditors('codex')).toEqual(['codex']);
+    expect(parseEditors('claude,codex')).toEqual(['claude', 'codex']);
+  });
+
+  it('reports codex as a valid option when validation fails', () => {
+    expect(() => parseEditors('gemini')).toThrow(
+      'Unknown editor(s): gemini. Valid options: claude, opencode, cursor, codex',
+    );
+  });
+
+  it('includes Codex in the interactive selector choices', () => {
+    expect(VALID_EDITORS).toContain('codex');
+    expect(EDITOR_CHOICES).toContainEqual({ name: 'Codex', value: 'codex' });
+  });
+});

--- a/test/post-install-message.test.ts
+++ b/test/post-install-message.test.ts
@@ -36,6 +36,14 @@ describe('printPostInstallMessage', () => {
     expect(output).toContain('Done! Skills are ready to use');
   });
 
+  it('prints the Codex telemetry limitation when codex is installed', () => {
+    printPostInstallMessage('test-org', ['codex']);
+    const output = consoleSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(output).toContain('Codex MCP auth uses AICTRL_API_KEY');
+    expect(output).toContain('Codex skill telemetry is not installed yet');
+    expect(output).not.toContain('/plugin uninstall');
+  });
+
   it('prints the cleanup reminder when claude and cursor are both installed', () => {
     printPostInstallMessage('multi-org', ['claude', 'cursor']);
     const output = consoleSpy.mock.calls.map(c => c.join(' ')).join('\n');

--- a/test/writers/codex.test.ts
+++ b/test/writers/codex.test.ts
@@ -35,7 +35,9 @@ describe('installCodex', () => {
   });
 
   const pluginPath = (plugin = 'aictrl-talentrix') =>
-    join(tempHome, '.agents', 'plugins', 'plugins', plugin);
+    join(tempHome, 'plugins', plugin);
+  const pluginCachePath = (plugin = 'aictrl-talentrix') =>
+    join(tempHome, '.codex', 'plugins', 'cache', 'personal', plugin, '1.0.0');
 
   it('writes a Codex plugin with fetched skills', async () => {
     await installCodex({
@@ -49,6 +51,11 @@ describe('installCodex', () => {
     expect(existsSync(join(pluginPath(), '.codex-plugin', 'plugin.json'))).toBe(true);
     expect(existsSync(join(pluginPath(), 'skills', 'code-review', 'SKILL.md'))).toBe(true);
     expect(existsSync(join(pluginPath(), 'skills', 'tdd', 'references', 'checklist.md'))).toBe(true);
+    expect(existsSync(join(pluginCachePath(), '.codex-plugin', 'plugin.json'))).toBe(true);
+    expect(existsSync(join(pluginCachePath(), 'skills', 'code-review', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(tempHome, '.agents', 'plugins', 'plugins', 'aictrl-talentrix'))).toBe(
+      false,
+    );
 
     const pluginJson = JSON.parse(
       await readFile(join(pluginPath(), '.codex-plugin', 'plugin.json'), 'utf-8'),
@@ -130,6 +137,8 @@ describe('installCodex', () => {
     expect(config).toContain('[mcp_servers.aictrl-talentrix]');
     expect(config).toContain('url = "https://aictrl.dev/talentrix/mcp"');
     expect(config).toContain('bearer_token_env_var = "AICTRL_API_KEY"');
+    expect(config).toContain('[plugins."aictrl-talentrix@personal"]');
+    expect(config).toContain('enabled = true');
     expect(config).not.toContain('sk_live');
 
     const mode = (await stat(codexConfigFile)).mode & 0o777;
@@ -168,6 +177,7 @@ describe('installCodex', () => {
 
     const config = await readFile(codexConfigFile, 'utf-8');
     expect((config.match(/\[mcp_servers\.aictrl-talentrix\]/g) ?? [])).toHaveLength(1);
+    expect((config.match(/\[plugins\."aictrl-talentrix@personal"\]/g) ?? [])).toHaveLength(1);
     expect(config).toContain('[mcp_servers.other]\nurl = "https://example.com/mcp"');
     expect(config).not.toContain('OLD_KEY');
   });
@@ -183,8 +193,6 @@ describe('installCodex', () => {
 
     const unrelatedPluginSkill = join(
       tempHome,
-      '.agents',
-      'plugins',
       'plugins',
       'other',
       'skills',

--- a/test/writers/codex.test.ts
+++ b/test/writers/codex.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, mkdir, writeFile, stat } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { existsSync } from 'fs';
+import { installCodex } from '../../src/writers/codex.js';
+import type { WritableSkill } from '../../src/writers/shared.js';
+
+describe('installCodex', () => {
+  let tempHome: string;
+  let codexConfigFile: string;
+  let codexMarketplaceFile: string;
+
+  const skills: WritableSkill[] = [
+    {
+      name: 'code-review',
+      markdown: '---\nname: code-review\n---\n\nReview code.',
+      files: [],
+    },
+    {
+      name: 'tdd',
+      markdown: '---\nname: tdd\n---\n\nTDD guide.',
+      files: [{ path: 'references/checklist.md', content: '# Checklist' }],
+    },
+  ];
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'aictrl-test-'));
+    codexConfigFile = join(tempHome, '.codex', 'config.toml');
+    codexMarketplaceFile = join(tempHome, '.agents', 'plugins', 'marketplace.json');
+  });
+
+  afterEach(async () => {
+    await rm(tempHome, { recursive: true });
+  });
+
+  const pluginPath = (plugin = 'aictrl-talentrix') =>
+    join(tempHome, '.agents', 'plugins', 'plugins', plugin);
+
+  it('writes a Codex plugin with fetched skills', async () => {
+    await installCodex({
+      orgSlug: 'talentrix',
+      skills,
+      baseUrl: 'https://aictrl.dev',
+      codexConfigFile,
+      codexMarketplaceFile,
+    });
+
+    expect(existsSync(join(pluginPath(), '.codex-plugin', 'plugin.json'))).toBe(true);
+    expect(existsSync(join(pluginPath(), 'skills', 'code-review', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(pluginPath(), 'skills', 'tdd', 'references', 'checklist.md'))).toBe(true);
+
+    const pluginJson = JSON.parse(
+      await readFile(join(pluginPath(), '.codex-plugin', 'plugin.json'), 'utf-8'),
+    );
+    expect(pluginJson.name).toBe('aictrl-talentrix');
+    expect(pluginJson.skills).toBe('./skills/');
+    expect(pluginJson.interface.defaultPrompt).toHaveLength(2);
+    expect(pluginJson.hooks).toBeUndefined();
+    expect(pluginJson.mcpServers).toBeUndefined();
+  });
+
+  it('registers the plugin in the personal marketplace and preserves existing entries', async () => {
+    await mkdir(join(codexMarketplaceFile, '..'), { recursive: true });
+    await writeFile(
+      codexMarketplaceFile,
+      JSON.stringify({
+        name: 'personal',
+        interface: { displayName: 'My Plugins' },
+        plugins: [
+          {
+            name: 'other-plugin',
+            source: { source: 'local', path: './plugins/other-plugin' },
+            policy: { installation: 'AVAILABLE', authentication: 'ON_INSTALL' },
+            category: 'Productivity',
+          },
+        ],
+      }),
+    );
+
+    await installCodex({
+      orgSlug: 'talentrix',
+      skills,
+      baseUrl: 'https://aictrl.dev',
+      codexConfigFile,
+      codexMarketplaceFile,
+    });
+
+    const marketplace = JSON.parse(await readFile(codexMarketplaceFile, 'utf-8'));
+    expect(marketplace.interface.displayName).toBe('My Plugins');
+    expect(
+      marketplace.plugins.find((p: { name: string }) => p.name === 'other-plugin'),
+    ).toBeDefined();
+
+    const aictrl = marketplace.plugins.find(
+      (p: { name: string }) => p.name === 'aictrl-talentrix',
+    );
+    expect(aictrl).toEqual({
+      name: 'aictrl-talentrix',
+      source: { source: 'local', path: './plugins/aictrl-talentrix' },
+      policy: { installation: 'INSTALLED_BY_DEFAULT', authentication: 'ON_USE' },
+      category: 'Productivity',
+    });
+  });
+
+  it('merges a bearer-token-env-var MCP server into existing Codex config', async () => {
+    await mkdir(join(codexConfigFile, '..'), { recursive: true });
+    await writeFile(
+      codexConfigFile,
+      [
+        'model = "gpt-5-codex"',
+        '',
+        '[mcp_servers.other]',
+        'url = "https://example.com/mcp"',
+        '',
+      ].join('\n'),
+    );
+
+    await installCodex({
+      orgSlug: 'talentrix',
+      skills,
+      baseUrl: 'https://aictrl.dev',
+      codexConfigFile,
+      codexMarketplaceFile,
+    });
+
+    const config = await readFile(codexConfigFile, 'utf-8');
+    expect(config).toContain('model = "gpt-5-codex"');
+    expect(config).toContain('[mcp_servers.other]\nurl = "https://example.com/mcp"');
+    expect(config).toContain('[mcp_servers.aictrl-talentrix]');
+    expect(config).toContain('url = "https://aictrl.dev/talentrix/mcp"');
+    expect(config).toContain('bearer_token_env_var = "AICTRL_API_KEY"');
+    expect(config).not.toContain('sk_live');
+
+    const mode = (await stat(codexConfigFile)).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('updates only the aictrl MCP block on re-run', async () => {
+    await mkdir(join(codexConfigFile, '..'), { recursive: true });
+    await writeFile(
+      codexConfigFile,
+      [
+        '[mcp_servers.aictrl-talentrix]',
+        'url = "https://old.example/talentrix/mcp"',
+        'bearer_token_env_var = "OLD_KEY"',
+        '',
+        '[mcp_servers.other]',
+        'url = "https://example.com/mcp"',
+        '',
+      ].join('\n'),
+    );
+
+    await installCodex({
+      orgSlug: 'talentrix',
+      skills,
+      baseUrl: 'https://aictrl.dev',
+      codexConfigFile,
+      codexMarketplaceFile,
+    });
+    await installCodex({
+      orgSlug: 'talentrix',
+      skills,
+      baseUrl: 'https://aictrl.dev',
+      codexConfigFile,
+      codexMarketplaceFile,
+    });
+
+    const config = await readFile(codexConfigFile, 'utf-8');
+    expect((config.match(/\[mcp_servers\.aictrl-talentrix\]/g) ?? [])).toHaveLength(1);
+    expect(config).toContain('[mcp_servers.other]\nurl = "https://example.com/mcp"');
+    expect(config).not.toContain('OLD_KEY');
+  });
+
+  it('clears only the managed plugin skills on re-install', async () => {
+    await installCodex({
+      orgSlug: 'talentrix',
+      skills,
+      baseUrl: 'https://aictrl.dev',
+      codexConfigFile,
+      codexMarketplaceFile,
+    });
+
+    const unrelatedPluginSkill = join(
+      tempHome,
+      '.agents',
+      'plugins',
+      'plugins',
+      'other',
+      'skills',
+      'keep',
+      'SKILL.md',
+    );
+    await mkdir(join(unrelatedPluginSkill, '..'), { recursive: true });
+    await writeFile(unrelatedPluginSkill, 'keep');
+
+    await installCodex({
+      orgSlug: 'talentrix',
+      skills: [{ name: 'deploy', markdown: 'Deploy.', files: [] }],
+      baseUrl: 'https://aictrl.dev',
+      codexConfigFile,
+      codexMarketplaceFile,
+    });
+
+    expect(existsSync(join(pluginPath(), 'skills', 'deploy', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(pluginPath(), 'skills', 'code-review'))).toBe(false);
+    expect(existsSync(unrelatedPluginSkill)).toBe(true);
+  });
+
+  it('rejects unsafe org slugs', async () => {
+    await expect(
+      installCodex({
+        orgSlug: '../evil',
+        skills,
+        baseUrl: 'https://aictrl.dev',
+        codexConfigFile,
+        codexMarketplaceFile,
+      }),
+    ).rejects.toThrow(/Invalid orgSlug/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Codex as a supported editor in CLI parsing and the interactive selector.
- Install a Codex local plugin with fetched aictrl skills and register it in the personal marketplace.
- Merge an aictrl Codex MCP config using `bearer_token_env_var = "AICTRL_API_KEY"` and document the current Codex telemetry limitation.

Closes #24

## Test plan
- [x] `npm test`
- [x] `npm run build`
- [x] Generated Codex plugin validated with the Codex plugin validator
