### PR TITLE
chore(release): v2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aictrl/plugin",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aictrl/plugin",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aictrl/plugin",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Set up aictrl skills, telemetry, and MCP for Claude Code, OpenCode, Cursor, and Codex",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump @aictrl/plugin to 2.2.1 for the Codex setup fix from PR #25.

## Test plan
- [x] npm run build
- [x] npm test
